### PR TITLE
Added support sharing settings

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ninelines-template",
-	"version": "2.6.1",
+	"version": "2.7.0",
 	"description": "Шаблон для разработки сайтов",
 	"scripts": {},
 	"author": "Dmitry Artemov <d.artemov@9-lines.com>",
@@ -19,8 +19,10 @@
 		"browser-sync": "2.26.3",
 		"connect-history-api-fallback": "1.6.0",
 		"cssnano": "4.1.10",
+		"del": "5.1.0",
 		"emitty": "1.4.0",
 		"gulp": "4.0.1",
+		"gulp-append-prepend": "1.0.8",
 		"gulp-debug": "4.0.0",
 		"gulp-eslint": "5.0.0",
 		"gulp-if": "2.0.2",

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -2,6 +2,7 @@ let gulp = require('gulp');
 let gulpLoadPlugins = require('gulp-load-plugins');
 let yargs = require('yargs');
 let path = require('path');
+let del = require('del');
 let webpackConfig = require('./webpack.config');
 
 let emittyPug;
@@ -12,7 +13,6 @@ let argv = yargs.default({
 	ci: false,
 	debug: true,
 	fix: false,
-	minify: false,
 	minifyHtml: null,
 	minifyCss: null,
 	minifyJs: null,
@@ -20,7 +20,7 @@ let argv = yargs.default({
 	notify: true,
 	open: true,
 	port: 3000,
-	spa: false,
+	spa: true,
 	throwErrors: false,
 }).argv;
 
@@ -60,6 +60,7 @@ let $ = gulpLoadPlugins({
 		'vinyl-buffer',
 		'webpack',
 		'webpack-stream',
+		'append-prepend',
 	],
 	scope: [
 		'dependencies',
@@ -430,20 +431,47 @@ gulp.task('zip', () => {
 		.pipe(gulp.dest('zip'));
 });
 
+gulp.task('share', () => {
+	if (webpackConfig.mode !== 'production' || !argv.spa) {
+		del([
+			'./build/index.php',
+			'./build/shareSettings.php',
+		]);
+	} else {
+		gulp.src('./build/index.html')
+			.pipe($.if(argv.debug, $.debug()))
+			.pipe($.appendPrepend.prependFile('./src/resources/shareSettings.php'))
+			.pipe($.rename('index.php'))
+			.pipe(gulp.dest('build'));
+		del([
+			'./build/index.html',
+			'./build/shareSettings.php',
+		]);
+	}
+
+	return gulp.src('./src/resources/share.php')
+		.pipe($.if(argv.debug, $.debug()))
+		.pipe($.appendPrepend.prependFile('./src/resources/shareSettings.php'))
+		.pipe(gulp.dest('build'));
+});
+
 gulp.task('lint', gulp.series(
 	'lint:pug',
 	'lint:scss',
 	'lint:js'
 ));
 
-gulp.task('build', gulp.parallel(
+gulp.task('build', gulp.series(
 	'copy',
-	'images',
-	'sprites:png',
-	'sprites:svg',
 	'pug',
-	'scss',
-	'js'
+	'share',
+	gulp.parallel(
+		'images',
+		'sprites:png',
+		'sprites:svg',
+		'scss',
+		'js'
+	)
 ));
 
 gulp.task('default', gulp.series(

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -20,7 +20,7 @@ let argv = yargs.default({
 	notify: true,
 	open: true,
 	port: 3000,
-	spa: true,
+	spa: false,
 	throwErrors: false,
 }).argv;
 

--- a/app/templates/src/resources/shareSettings.php
+++ b/app/templates/src/resources/shareSettings.php
@@ -1,0 +1,28 @@
+<?php
+
+$host = '';
+$title = '';
+$description = '';
+$image = '';
+$redirect = '/';
+
+// Uncomment the code below and fill in the pages if necessary
+// $pages = [
+// 	'page/1' => [
+// 		'title' => '',
+// 		'description' => '',
+// 		'image' => '',
+// 		'redirect' => '',
+// 	],
+// ];
+
+$page = @$pages[$_GET['page']];
+
+if ($page) {
+	$title = !is_null(@$page['title']) ? $page['title'] : $title;
+	$description = !is_null(@$page['description']) ? $page['description'] : $description;
+	$image = !is_null(@$page['image']) ? $page['image'] : $image;
+	$redirect = !is_null(@$page['redirect']) ? $page['redirect'] : "/{$_GET['page']}";
+}
+
+?>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-ninelines-template",
-	"version": "2.6.1-1",
+	"version": "2.7.0-0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-ninelines-template",
-	"version": "2.6.1-1",
+	"version": "2.7.0-0",
 	"description": "Project template generator",
 	"license": "ISC",
 	"repository": "ninelines-team/generator-ninelines-template",


### PR DESCRIPTION
По умолчанию добавлен файл `/resource/shareSettings.php` (**он используется только для настроек шерингов**), при любом раскладе он удаляется и в конечном билде никак не окажется, 
Настройки из файла `shareSettings.php` попадают в 2 файла, `share.php` и `index.php`, но, в файл `share.php` настройки попадают при любом билде, а в `index.php` только при серверном билде (или ручном с ключом `--minify`)
При разных сборках (с ключом `--minify` или без) автоматически будет подставляться расширение для файла `index` (`.html` или `.php`) и удаляться ненужны в данный момент файл

Дефолтный ключ `minify` был удалён т.к. сборка никак не получала его при ручном указании (`--minify`), сейчас же всё работает корректно

По умолчанию в `build` таске изменена последовательность - это необходимо для правильной сборки файлов